### PR TITLE
PHP Version and magento 2.4 compatibility

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -107,7 +107,7 @@ class Data extends AbstractHelper
         StoreManagerInterface $storeManager,
         Pool $cacheFrontendPool,
         DeploymentConfig $deploymentConfig,
-        Json $serializer = null
+        Json $serializer
     ) {
         $this->_storeManager = $storeManager;
         $this->_localeDate = $localeDate;
@@ -187,14 +187,14 @@ class Data extends AbstractHelper
                     $this->_services[] = $this->_processRedisOptions(__('Session'), $session['redis'], true);
                 }
 
-                if ($caches['default']['backend'] && $caches['default']['backend'] == 'Magento\Framework\Cache\Backend\Redis') {
+                if (in_array($caches['default']['backend'] && $caches['default']['backend'], ['Magento\Framework\Cache\Backend\Redis', 'Cm_Cache_Backend_Redis'])) {
                     $this->_services[] = $this->_processRedisOptions(
                         __('Cache'),
                         $caches['default']['backend_options']
                     );
                 }
 
-                if ($caches['page_cache']['backend'] && $caches['page_cache']['backend'] == 'Magento\Framework\Cache\Backend\Redis') {
+                if (in_array($caches['page_cache']['backend'] && $caches['page_cache']['backend'], ['Magento\Framework\Cache\Backend\Redis', 'Cm_Cache_Backend_Redis'])) {
                     $this->_services[] = $this->_processRedisOptions(
                         __('Page Cache'),
                         $caches['page_cache']['backend_options']
@@ -227,24 +227,17 @@ class Data extends AbstractHelper
      */
     protected function _processRedisOptions($name, $redisOptions, $isSession = false)
     {
+        $default = [
+            'server' => '127.0.0.1',
+            'port' => 6379,
+            'database' => '',
+            'password' => '',
+            'timeout' => '2.5'
+        ];
         if ($isSession) {
-            $default = [
-                'server' => '127.0.0.1',
-                'port' => 6379,
-                'database' => '',
-                'password' => '',
-                'timeout' => '2.5'
-            ];
             $redisOptions['server'] = !empty($redisOptions['host']) ? $redisOptions['host'] : '';
             $redisOptions = array_merge($default, $redisOptions);
         } else {
-            $default = [
-                'server' => '127.0.0.1',
-                'port' => 6379,
-                'database' => '',
-                'password' => '',
-                'timeout' => '2.5'
-            ];
             $redisOptions = array_merge($default, $redisOptions);
         }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -187,14 +187,14 @@ class Data extends AbstractHelper
                     $this->_services[] = $this->_processRedisOptions(__('Session'), $session['redis'], true);
                 }
 
-                if ($caches['default']['backend'] && $caches['default']['backend'] == 'Cm_Cache_Backend_Redis') {
+                if ($caches['default']['backend'] && $caches['default']['backend'] == 'Magento\Framework\Cache\Backend\Redis') {
                     $this->_services[] = $this->_processRedisOptions(
                         __('Cache'),
                         $caches['default']['backend_options']
                     );
                 }
 
-                if ($caches['page_cache']['backend'] && $caches['page_cache']['backend'] == 'Cm_Cache_Backend_Redis') {
+                if ($caches['page_cache']['backend'] && $caches['page_cache']['backend'] == 'Magento\Framework\Cache\Backend\Redis') {
                     $this->_services[] = $this->_processRedisOptions(
                         __('Page Cache'),
                         $caches['page_cache']['backend_options']

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": "~7.0.13|~7.1.0|~7.2.0|~7.3.0|~7.4.0"
     },
     "type": "magento2-module",
-    "version": "1.1.2",
+    "version": "1.1.2.1",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "php": "~7.0.13|~7.1.0|~7.2.0|~7.3.0|~7.4.0"
     },
     "type": "magento2-module",
-    "version": "1.1.2.1",
+    "version": "1.1.3",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "tigrensolutions/module-redis-manager",
     "description": "Tigren Redis Manager for Magento 2",
     "require": {
-        "php": "~7.0.13|~7.1.0|~7.2.0"
+        "php": "~7.0.13|~7.1.0|~7.2.0|~7.3.0|~7.4.0"
     },
     "type": "magento2-module",
     "version": "1.1.2",


### PR DESCRIPTION
The validation check in helper needed update. I don't know if this is just since magento 2.4, but making assumption it is since module compatibly states 2.3 working, but in 2.4 the validation check required to be changed
